### PR TITLE
SKIT-150 Adding OS Specific props to schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@merokudao/dapp-store-registry",
-  "version": "0.1.51",
+  "version": "0.1.52",
   "description": "The dApp Store registry for MerokuDAO dAapp Store",
   "repository": {
     "type": "git",

--- a/src/interfaces/dAppSchema.ts
+++ b/src/interfaces/dAppSchema.ts
@@ -43,6 +43,9 @@ export interface DAppSchema {
    */
   description: string;
 
+  external_url?: string;
+
+  image?: string;
   /**
    * The URL of the dApp. This is optional. If specified, the dApp will be shown as a
    * link on the dApp store

--- a/src/interfaces/dAppSchema.ts
+++ b/src/interfaces/dAppSchema.ts
@@ -46,6 +46,13 @@ export interface DAppSchema {
   external_url?: string;
 
   image?: string;
+
+  attributes?: {
+    trait_type: string;
+    value: string;
+    display_type: string;
+  }[];
+
   /**
    * The URL of the dApp. This is optional. If specified, the dApp will be shown as a
    * link on the dApp store

--- a/src/schemas/merokuDappStore.dAppSchema.json
+++ b/src/schemas/merokuDappStore.dAppSchema.json
@@ -14,6 +14,20 @@
       "type": "string",
       "description": "A detailed description of the dApp"
     },
+    "external_url": {
+      "type": "string",
+      "description": "The URL of the dApp. This is used by OpenSea",
+      "format": "uri",
+      "pattern": "^(https?|http?|ipfs?)://",
+      "minLength": 1
+    },
+    "image": {
+      "type": "string",
+      "format": "uri",
+      "pattern": "^(https?|http?|ipfs?)://",
+      "minLength": 1,
+      "description": "A URL to the logo of the dApp. Should be square and 512x512 in PNG format. Used by OpenSea"
+    },
     "appUrl": {
       "type": "string",
       "description": "The URL of the dApp",

--- a/src/schemas/merokuDappStore.dAppSchema.json
+++ b/src/schemas/merokuDappStore.dAppSchema.json
@@ -16,7 +16,7 @@
     },
     "external_url": {
       "type": "string",
-      "description": "The URL of the dApp. This is used by OpenSea",
+      "description": "The URL of the dApp. This is used by OpenSea. This should be set to Meroku Protocol Explorer.",
       "format": "uri",
       "pattern": "^(https?|http?|ipfs?)://",
       "minLength": 1
@@ -26,7 +26,28 @@
       "format": "uri",
       "pattern": "^(https?|http?|ipfs?)://",
       "minLength": 1,
-      "description": "A URL to the logo of the dApp. Should be square and 512x512 in PNG format. Used by OpenSea"
+      "description": "A URL to the logo of the dApp. Should be square and 512x512 in PNG format. Used by OpenSea. This should automatically be set to the app logo from images field."
+    },
+    "attributes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["trait_type", "value"],
+        "properties": {
+          "display_type": {
+            "type": "string",
+            "description": "The display type of the trait"
+          },
+          "trait_type": {
+            "type": "string",
+            "description": "The trait type of the trait"
+          },
+          "value": {
+            "type": "string",
+            "description": "The value of the trait type"
+          }
+        }
+      }
     },
     "appUrl": {
       "type": "string",


### PR DESCRIPTION
- [x] Add [OS Metadata structure](https://docs.opensea.io/docs/metadata-standards#metadata-structure) to Meroku Schema